### PR TITLE
feat: allow `conan >=1.41.0, <2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-conan = "1.41.0"
+conan = "^1.41.0"
 packageurl-python = "^0.9.6"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Also permit conan version up to 1.49.x to avoid conflicts in environment setup.
Possibly also higher (1.5x) would be feasible but do not seem critical right now.

Unclear to me:
Is it required to also update:
https://github.com/CycloneDX/cyclonedx-conan/blob/main/poetry.lock
to get the pip repository dependency information updated? This seems to be a generated file, so I'd rather ask the admins of the project to update it with less hardcoded versions.