### PR TITLE
Add an option to exclude development dependencies from the SBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The command line options are aligned to the standard Conan options.
 
 ```text
 $ cyclonedx-conan --help
-usage: command.py [-h] [-if INSTALL_FOLDER] [-db [DRY_BUILD]] [-b [BUILD]] [-r REMOTE] [-u] [-l LOCKFILE] [--lockfile-out LOCKFILE_OUT]
+usage: command.py [-h] [-if INSTALL_FOLDER] [-db [DRY_BUILD]] [--exclude-dev] [-b [BUILD]] [-r REMOTE] [-u] [-l LOCKFILE] [--lockfile-out LOCKFILE_OUT]
                   [-e ENV_HOST] [-e:b ENV_BUILD] [-e:h ENV_HOST] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
                   [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
                   [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
@@ -63,6 +63,7 @@ optional arguments:
                         setting/option it will raise an error.
   -db [DRY_BUILD], --dry-build [DRY_BUILD]
                         Apply the --build argument to output the information, as it would be done by the install command
+  --exclude-dev         Exclude development dependencies from the BOM
   -b [BUILD], --build [BUILD]
                         Given a build policy, return an ordered list of packages that would be built from sources during the install
                         command

--- a/src/command.py
+++ b/src/command.py
@@ -28,7 +28,7 @@ from conans.client.command import Command as ConanCommand, OnceArgument, Extende
 from conans.client.graph.graph import DepsGraph, Node
 from conans.errors import ConanMigrationError, ConanException
 from packageurl import PackageURL
-from typing import List
+from typing import Set
 
 
 class CycloneDXCommand:
@@ -120,8 +120,7 @@ class CycloneDXCommand:
         required_ids = set()
         if self._arguments.exclude_dev:
             visited_ids = set()
-            node: Node
-            to_visit = set(node for node in deps_graph.nodes if node.ref is None)
+            to_visit: Set[Node] = set(node for node in deps_graph.nodes if node.ref is None)
             while to_visit:
                 node = to_visit.pop()
                 if node.id in visited_ids:

--- a/src/command.py
+++ b/src/command.py
@@ -117,8 +117,8 @@ class CycloneDXCommand:
             'dependencies': [],
         }
 
+        required_ids = set()
         if self._arguments.exclude_dev:
-            required_ids = set()
             to_visit: List[Node] = []
             visited_ids = set()
             node: Node
@@ -147,12 +147,18 @@ class CycloneDXCommand:
                 }
                 for dependency in node.dependencies:
                     purl = get_purl(dependency.dst.remote, dependency.dst.ref)
-                    if self._arguments.exclude_dev and str(dependency.dst.id) not in required_ids:
+                    if (
+                        self._arguments.exclude_dev
+                        and str(dependency.dst.id) not in required_ids
+                    ):
                         continue
                     dependencies['dependsOn'].append(str(purl))
                 bom['dependencies'].append(dependencies)
             else:
-                if self._arguments.exclude_dev and str(node.id) not in required_ids:
+                if (
+                    self._arguments.exclude_dev
+                    and str(node.id) not in required_ids
+                ):
                     continue
                 purl = get_purl(node.remote, node.ref)
                 component = {
@@ -170,7 +176,10 @@ class CycloneDXCommand:
                     'dependsOn': [],
                 }
                 for dependency in node.dependencies:
-                    if self._arguments.exclude_dev and str(dependency.dst.id) not in required_ids:
+                    if (
+                        self._arguments.exclude_dev
+                        and str(dependency.dst.id) not in required_ids
+                    ):
                         continue
                     dep_purl = get_purl(dependency.dst.remote, dependency.dst.ref)
                     dependencies['dependsOn'].append(str(dep_purl))

--- a/src/command.py
+++ b/src/command.py
@@ -119,13 +119,9 @@ class CycloneDXCommand:
 
         required_ids = set()
         if self._arguments.exclude_dev:
-            to_visit: List[Node] = []
             visited_ids = set()
             node: Node
-            for node in deps_graph.nodes:
-                if node.ref is None:
-                    # top level component
-                    to_visit.append(node)
+            to_visit = set(node for node in deps_graph.nodes if node.ref is None)
             while to_visit:
                 node = to_visit.pop()
                 if node.id in visited_ids:
@@ -134,7 +130,7 @@ class CycloneDXCommand:
                 required_ids.add(node.id)
                 for dependency in node.dependencies:
                     if str(dependency.dst.id) in node.graph_lock_node.requires:
-                        to_visit.append(dependency.dst)
+                        to_visit.add(dependency.dst)
 
         for node in deps_graph.nodes:
             if node.ref is None:

--- a/src/command.py
+++ b/src/command.py
@@ -25,9 +25,10 @@ import sys
 from uuid import uuid4
 from conans.client.conan_api import Conan, ProfileData
 from conans.client.command import Command as ConanCommand, OnceArgument, Extender, _add_common_install_arguments
-from conans.client.graph.graph import DepsGraph
+from conans.client.graph.graph import DepsGraph, Node
 from conans.errors import ConanMigrationError, ConanException
 from packageurl import PackageURL
+from typing import List
 
 
 class CycloneDXCommand:
@@ -53,6 +54,11 @@ class CycloneDXCommand:
         dry_build_help = ("Apply the --build argument to output the information, "
                           "as it would be done by the install command")
         parser.add_argument("-db", "--dry-build", action=Extender, nargs="?", help=dry_build_help)
+        exclude_dev_help = 'Exclude development dependencies from the BOM'
+        parser.add_argument(
+            '--exclude-dev', action='store_true',
+            help=exclude_dev_help, dest='exclude_dev'
+        )
         build_help = ("Given a build policy, return an ordered list of packages that would be built"
                       " from sources during the install command")
 
@@ -110,6 +116,26 @@ class CycloneDXCommand:
             'components': [],
             'dependencies': [],
         }
+
+        if self._arguments.exclude_dev:
+            required_ids = set()
+            to_visit: List[Node] = []
+            visited_ids = set()
+            node: Node
+            for node in deps_graph.nodes:
+                if node.ref is None:
+                    # top level component
+                    to_visit.append(node)
+            while to_visit:
+                node = to_visit.pop()
+                if node.id in visited_ids:
+                    continue
+                visited_ids.add(node.id)
+                required_ids.add(node.id)
+                for dependency in node.dependencies:
+                    if str(dependency.dst.id) in node.graph_lock_node.requires:
+                        to_visit.append(dependency.dst)
+
         for node in deps_graph.nodes:
             if node.ref is None:
                 # top level component
@@ -121,9 +147,13 @@ class CycloneDXCommand:
                 }
                 for dependency in node.dependencies:
                     purl = get_purl(dependency.dst.remote, dependency.dst.ref)
+                    if self._arguments.exclude_dev and str(dependency.dst.id) not in required_ids:
+                        continue
                     dependencies['dependsOn'].append(str(purl))
                 bom['dependencies'].append(dependencies)
             else:
+                if self._arguments.exclude_dev and str(node.id) not in required_ids:
+                    continue
                 purl = get_purl(node.remote, node.ref)
                 component = {
                     'bom-ref': str(purl),
@@ -140,6 +170,8 @@ class CycloneDXCommand:
                     'dependsOn': [],
                 }
                 for dependency in node.dependencies:
+                    if self._arguments.exclude_dev and str(dependency.dst.id) not in required_ids:
+                        continue
                     dep_purl = get_purl(dependency.dst.remote, dependency.dst.ref)
                     dependencies['dependsOn'].append(str(dep_purl))
                 bom['dependencies'].append(dependencies)


### PR DESCRIPTION
Add an option to exclude development dependencies from the SBOM

This aims to address https://github.com/CycloneDX/cyclonedx-conan/issues/85

This adds an  `--exclude-dev` command line option, which allows you to exclude development dependencies from the generated SBOM, for instance:
`cyclonedx-conan -l conan.lock conanfile.txt --exclude-dev`